### PR TITLE
chore: migrate from fish to nushell

### DIFF
--- a/nix/files/nushell/config.nu
+++ b/nix/files/nushell/config.nu
@@ -1,0 +1,65 @@
+$env.config = {
+  show_banner: false
+  edit_mode: "vi"
+  shell_integration: {
+    osc2: true
+    osc7: true
+    osc8: true
+    osc9_9: false
+    osc133: true
+    osc633: true
+    reset_application_mode: true
+  }
+  keybindings: [
+    {
+      name: fzf_history
+      modifier: control
+      keycode: char_r
+      mode: [emacs, vi_normal, vi_insert]
+      event: {
+        send: executehostcommand
+        cmd: "commandline edit --replace (
+          history
+          | each { |it| $it.command }
+          | uniq
+          | reverse
+          | str join (char -i 0)
+          | fzf --read0 --layout=reverse --height=40% -q (commandline)
+          | decode utf-8
+          | str trim
+        )"
+      }
+    }
+    {
+      name: fzf_files
+      modifier: control
+      keycode: char_t
+      mode: [emacs, vi_normal, vi_insert]
+      event: {
+        send: executehostcommand
+        cmd: "commandline edit --insert (
+          fd --type f --hidden --follow --exclude .git
+          | fzf --layout=reverse --height=40%
+          | decode utf-8
+          | str trim
+        )"
+      }
+    }
+  ]
+}
+
+# Carapace completions
+$env.CARAPACE_BRIDGES = 'zsh,fish,bash,inshellisense'
+
+let carapace_completer = {|spans: list<string>|
+  carapace $spans.0 nushell ...$spans
+  | from json
+  | if ($in | default [] | where value =~ '^-.*ERR$' | is-empty) { $in } else { null }
+}
+
+$env.config.completions = {
+  external: {
+    enable: true
+    completer: $carapace_completer
+  }
+}

--- a/nix/files/nushell/env.nu
+++ b/nix/files/nushell/env.nu
@@ -1,0 +1,24 @@
+# Ghostty shell integration
+# Nushell uses OSC sequences via shell_integration config
+# No explicit sourcing needed
+
+# cargo
+$env.PATH = ($env.PATH | prepend $"($env.HOME)/.cargo/bin")
+
+# pnpm
+$env.PNPM_HOME = $"($env.HOME)/.local/share/pnpm"
+$env.PATH = ($env.PATH | prepend $env.PNPM_HOME)
+
+# foundry
+$env.FOUNDRY_DIR = $"($env.HOME)/.foundry"
+$env.FOUNDRY_DISABLE_NIGHTLY_WARNING = "true"
+$env.PATH = ($env.PATH | prepend $"($env.FOUNDRY_DIR)/bin")
+
+# pg_config
+$env.PATH = ($env.PATH | prepend "/Applications/Postgres.app/Contents/Versions/latest/bin")
+
+# fnm (Fast Node Manager)
+if (which fnm | is-not-empty) {
+  ^fnm env --json | from json | load-env
+  $env.PATH = ($env.PATH | prepend $"($env.FNM_MULTISHELL_PATH)/bin")
+}

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -12,7 +12,6 @@ in
   home.packages = with pkgs; [
     amber
     asciinema
-    babelfish
     bat
     btop
     cachix
@@ -32,6 +31,7 @@ in
     just
     neovim
     nixfmt-rfc-style
+    nushell
     ripgrep
     rustup
     starship
@@ -41,7 +41,7 @@ in
     ".ignore".source = ../files/ignore;
     ".ssh/tom.pub".source = ../files/tom.pub;
   };
-  home.shell.enableFishIntegration = true;
+  home.shell.enableNushellIntegration = true;
   home.stateVersion = "23.05";
   home.sessionVariables = {
     EDITOR = "nvim";

--- a/nix/modules/shell.nix
+++ b/nix/modules/shell.nix
@@ -2,43 +2,8 @@
 {
   programs.nushell = {
     enable = true;
-    configFile.text = ''
-      $env.config = {
-        show_banner: false
-        edit_mode: "vi"
-        shell_integration: {
-          osc2: true
-          osc7: true
-          osc8: true
-          osc9_9: false
-          osc133: true
-          osc633: true
-          reset_application_mode: true
-        }
-      }
-    '';
-    envFile.text = ''
-      # Ghostty shell integration
-      if ($env.GHOSTTY_RESOURCES_DIR? | is-not-empty) {
-        # Nushell doesn't have native Ghostty integration yet
-        # Using OSC sequences via shell_integration config instead
-      }
-
-      # cargo
-      $env.PATH = ($env.PATH | prepend $"($env.HOME)/.cargo/bin")
-
-      # pnpm
-      $env.PNPM_HOME = $"($env.HOME)/.local/share/pnpm"
-      $env.PATH = ($env.PATH | prepend $env.PNPM_HOME)
-
-      # foundry
-      $env.FOUNDRY_DIR = $"($env.HOME)/.foundry"
-      $env.FOUNDRY_DISABLE_NIGHTLY_WARNING = "true"
-      $env.PATH = ($env.PATH | prepend $"($env.FOUNDRY_DIR)/bin")
-
-      # pg_config
-      $env.PATH = ($env.PATH | prepend "/Applications/Postgres.app/Contents/Versions/latest/bin")
-    '';
+    configFile.source = ../files/nushell/config.nu;
+    envFile.source = ../files/nushell/env.nu;
     shellAliases = {
       a = "amp";
       b = "bun";


### PR DESCRIPTION
Migrates shell configuration from fish to nushell.

## Changes
- Replace fish config with nushell in `shell.nix`
- Update home-manager to use nushell integration
- Remove babelfish (fish-related), add nushell to packages
- Convert shell aliases and environment setup to nushell syntax
- Enable vi edit mode and shell integration

## Notes
- Ghostty shell integration uses OSC sequences (no native nushell integration yet)
- `fnm env` and `fzf` sourcing removed (nushell doesn't support direct sourcing of fish/bash scripts)
  - Consider `fnm env --shell=nu` or carapace for completions