### PR TITLE
docs: add public GitHub content policy for agent guidelines

### DIFF
--- a/nix/files/AGENTS.md
+++ b/nix/files/AGENTS.md
@@ -25,6 +25,19 @@ Use conventional commits (`feat:`, `fix:`, `perf:`, `chore:`, `docs:`, `test:`, 
 
 Be specific: `perf: add specialized multiplication for 8 limbs` not `perf: optimize mul`
 
+## Public GitHub Content Policy
+
+When creating or editing anything publicly visible on GitHub (issues, PRs, code, comments):
+
+### DO NOT
+- Include direct quotations from Slack messages
+- Mention specific partners or companies by name
+
+### ALWAYS
+- Ask for user confirmation before mentioning anything that could pose a security risk to the network (vulnerabilities, exploits, attack vectors - even minor ones)
+- Paraphrase internal discussions rather than quoting them
+- Use generic descriptions instead of partner names (e.g., "a partner" or "an integration partner")
+
 ## Critical Reminders
 
 **DO NOT:**


### PR DESCRIPTION
Adds rules for publicly visible GitHub content (issues, PRs, code, comments):

- No direct quotations from Slack messages
- No specific partner/company names (use generic descriptions instead)
- Require user confirmation before mentioning anything that could pose a security risk to the network

This ensures sensitive internal discussions and partnerships are not inadvertently disclosed in public repositories.